### PR TITLE
Swap unirest for rest-client, couple more methods

### DIFF
--- a/lib/quip/client.rb
+++ b/lib/quip/client.rb
@@ -1,4 +1,5 @@
-require 'unirest'
+require 'json'
+require 'rest-client'
 
 module Quip
   class QuipClient
@@ -13,14 +14,9 @@ module Quip
       @request_timeout = options.fetch(:request_timeout, 10)
     end
 
-    def get_authenticated_user
-      get_json('users/current')
-    end
+    # DOCS: https://quip.com/api/reference
 
-    def get_folder(folder_id)
-      get_json("folders/#{folder_id}")
-    end
-
+    # THREADS
     def get_thread(thread_id)
       get_json("threads/#{thread_id}")
     end
@@ -67,34 +63,82 @@ module Quip
     end
 
     def get_blob(thread_id, blob_id)
-      get_json("blob/#{thread_id}/#{blob_id}")
+      get_raw("blob/#{thread_id}/#{blob_id}")
     end
 
+    def add_blob(thread_id, blob)
+      post_json("blob", {
+        thread_id: thread_id,
+        blob: blob
+      })
+    end
+
+    # MESSAGES
     def get_messages(thread_id)
       get_json("messages/#{thread_id}")
     end
 
-    def post_message(thread_id, message)
+    def add_message(thread_id, message)
       post_json("messages/new", {thread_id: thread_id, content: message})
+    end
+
+    # FOLDERS
+    def get_folder(folder_id)
+      get_json("folders/#{folder_id}")
+    end
+
+    def get_folders(folder_ids)
+      get_json("folders/?ids=#{folder_ids.join(',')}")
+    end
+
+    def create_folder(title, options = {})
+      post_json("folders/new", {
+        title: title,
+        parent_id: options.fetch(:parent_id, nil),
+        color: options.fetch(:color, nil),
+        member_ids: options.fetch(:member_ids, []).join(',')
+      })
+    end
+
+    # TODO
+    # def change_folder(folder_id)
+    # end
+
+    def add_folder_members(folder_id, member_ids)
+      post_json("folders/add-members", {
+        folder_id: folder_id,
+        member_ids: member_ids.join(',')
+      })
+    end
+
+    # USERS
+    def get_user(user_id)
+      get_json("users/#{user_id}")
+    end
+
+    def get_users(user_ids)
+      get_json("users/?ids=#{user_ids.join(',')}")
+    end
+
+    def get_authenticated_user
+      get_json('users/current')
     end
 
     private
 
-    def get_json(path)
-      response = Unirest.get("#{base_url}/#{path}", headers: {
-        'Authorization' => "Bearer #{access_token}"
-      })
-
+    def get_raw(path)
+      response = RestClient.get("#{base_url}/#{path}", {Authorization: "Bearer #{access_token}"})
       response.body
     end
 
-    def post_json(path, data)
-      response = Unirest.post("#{base_url}/#{path}", headers: {
-        'Authorization' => "Bearer #{access_token}" }, 
-        parameters: data
-      )
+    def get_json(path)
+      response = RestClient.get("#{base_url}/#{path}", {Authorization: "Bearer #{access_token}"})
+      JSON.parse(response.body)
+    end
 
-      response.body
+    def post_json(path, data)
+      response = RestClient.post("#{base_url}/#{path}", data, {Authorization: "Bearer #{access_token}"})
+      JSON.parse(response.body)
     end
   end
 end

--- a/lib/quip/version.rb
+++ b/lib/quip/version.rb
@@ -1,3 +1,3 @@
 module Quip
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/quip.gemspec
+++ b/quip.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'unirest'
+  spec.add_dependency 'rest-client'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'pry'

--- a/spec/quip_client_spec.rb
+++ b/spec/quip_client_spec.rb
@@ -20,22 +20,7 @@ describe Quip::QuipClient do
   context 'authenticated client' do
     let(:client) { Quip::QuipClient.new(access_token: 'example') }
 
-    specify '#get_authenticated_user' do
-      stub_request(:get, client.base_url+'/users/current')
-        .to_return(body: '{"name": "Joffrey Baratheon"}')
-
-      user = client.get_authenticated_user()
-      expect(user['name']).to eq('Joffrey Baratheon')
-    end
-
-    specify '#get_folder' do
-      stub_request(:get, client.base_url+'/folders/ZYbAOAbHPyR')
-        .to_return(body: '{"folder": {"title": "The true king of Westeros"}}')
-
-      desktop = client.get_folder('ZYbAOAbHPyR')
-      expect(desktop['folder']['title']).to eq('The true king of Westeros')
-    end
-
+    # THREADS
     specify '#get_thread' do
       stub_request(:get, client.base_url+'/threads/YeXAAA2Uwb3')
         .to_return(body: '{"html": "<h1>Valor Morghulis</h1>"}')
@@ -48,7 +33,7 @@ describe Quip::QuipClient do
       stub_request(:get, client.base_url+'/threads/')
         .with(query: {"ids" => "CQXAAAP8MkR,YTWAAAiKUqp" })
         .to_return(body: '{
-          "CQXAAAP8MkR": {"html": "<h1>Valar Morghulis</h1>"}, 
+          "CQXAAAP8MkR": {"html": "<h1>Valar Morghulis</h1>"},
           "YTWAAAiKUqp": {"html": "<h1>Valar Dohaeris</h1>"}
         }')
 
@@ -64,7 +49,7 @@ describe Quip::QuipClient do
           "max_updated_usec" => 1399749767280351
         })
         .to_return(body: '{
-          "JLEAAAn9lAQ": {"html": "<h1>Kingslayer</h1>"}, 
+          "JLEAAAn9lAQ": {"html": "<h1>Kingslayer</h1>"},
           "DWRAOA5qGV9": {"thread": {"updated_usec": 1399749767280349}}
         }')
 
@@ -117,6 +102,16 @@ describe Quip::QuipClient do
       expect(blob).to eq('\x88\xE8\xFF\xD3T\x88\x00\x00\x00')
     end
 
+    specify '#add_blob' do
+      stub_request(:post, client.base_url+'/blob')
+        .to_return(body: '{"id": "1234", "url": "/blob/BobLoblaw"}')
+
+      blob = client.add_blob('JZbAAAb9x5x', "Blobbity blob blob. Bob Loblaw.")
+      expect(blob['id']).to eq("1234")
+    end
+
+
+    # MESSAGES
     specify '#get_messages' do
       stub_request(:get, client.base_url+'/messages/OLJAAAo0ggF')
         .to_return(body: '[{"text": "I am the king! I will punish you."}]')
@@ -125,12 +120,80 @@ describe Quip::QuipClient do
       expect(messages[0]['text']).to eq("I am the king! I will punish you.")
     end
 
-    specify '#post_message' do
+    specify '#add_message' do
       stub_request(:post, client.base_url+'/messages/new')
         .to_return(body: '{"text": "The king can do as he likes!"}')
 
-      message = client.post_message('YTWAAAiKUqp', "The king can do as he likes!")
+      message = client.add_message('YTWAAAiKUqp', "The king can do as he likes!")
       expect(message['text']).to eq("The king can do as he likes!")
     end
+
+    # FOLDERS
+    specify '#get_folder' do
+      stub_request(:get, client.base_url+'/folders/ZYbAOAbHPyR')
+        .to_return(body: '{"folder": {"title": "The true king of Westeros"}}')
+
+      desktop = client.get_folder('ZYbAOAbHPyR')
+      expect(desktop['folder']['title']).to eq('The true king of Westeros')
+    end
+
+    specify '#get_folders' do
+      stub_request(:get, client.base_url+'/folders/')
+        .with(query: {"ids" => "DIOAOAFIRxA,ISIAOACCbr4" })
+        .to_return(body: '{
+          "DIOAOAFIRxA": {"folder": {"title": "noodles"}},
+          "ISIAOACCbr4": {"folder": {"title": "tamales"}}
+        }')
+
+      folders = client.get_folders(['DIOAOAFIRxA','ISIAOACCbr4'])
+      expect(folders['DIOAOAFIRxA']['folder']['title']).to eq('noodles')
+      expect(folders['ISIAOACCbr4']['folder']['title']).to eq('tamales')
+    end
+
+    specify '#create_folder' do
+      stub_request(:post, client.base_url+'/folders/new')
+        .to_return(body: '{"title": "Im a little teapot"}')
+
+      folder = client.create_folder("Im a little teapot")
+      expect(folder['title']).to eq("Im a little teapot")
+    end
+
+    # TODO
+    # specify '#change_folder' do
+    # end
+
+    specify '#add_folder_members' do
+      stub_request(:post, client.base_url+'/folders/add-members')
+        .to_return(body: '{"folder": {"id": "FFJAOAcKhkX"}, "member_ids": ["KaDAEAinU0V", "HFCAEA8XZiw"]}')
+
+      members = client.add_folder_members("FFJAOAcKhkX", ["KaDAEAinU0V", "HFCAEA8XZiw"])
+      expect(members['member_ids']).to eq(["KaDAEAinU0V", "HFCAEA8XZiw"])
+    end
+
+    specify '#add_thread_members' do
+      stub_request(:post, client.base_url+'/threads/add-members')
+        .to_return(body: '{"user_ids": ["C3Rc3iR0b0"]}')
+
+      members = client.add_thread_members("HTPAAAdSbAm", ["C3Rc3iR0b0"])
+      expect(members['user_ids']).to eq(["C3Rc3iR0b0"])
+    end
+
+    # USERS
+    specify '#get_user' do
+      stub_request(:get, client.base_url+'/users/1')
+        .to_return(body: '{"name": "Joffrey Baratheon"}')
+
+      user = client.get_user('1')
+      expect(user['name']).to eq('Joffrey Baratheon')
+    end
+
+    specify '#get_authenticated_user' do
+      stub_request(:get, client.base_url+'/users/current')
+        .to_return(body: '{"name": "Joffrey Baratheon"}')
+
+      user = client.get_authenticated_user()
+      expect(user['name']).to eq('Joffrey Baratheon')
+    end
+
   end
 end


### PR DESCRIPTION
Hi, Unirest seems to no longer be maintained, which was causing a dependency issue for me with rest-client. To resolve I replaced unirest with plain 'ol rest-client, and added a few quip endpoints while I was at it, with specs. Bumped the version by 1/100 to reflect the new methods too. Cheers.